### PR TITLE
Better error handling when `nil`-ish polylines are passed to `encode`.

### DIFF
--- a/ext/lazer_lines/encoder.c
+++ b/ext/lazer_lines/encoder.c
@@ -66,6 +66,9 @@ VALUE method_encode(VALUE self, VALUE line_string, VALUE precision_digits) {
   double oldLon = 0.0;
   int precision = pow(10, FIX2INT(precision_digits));
   for (i = 0; i < cPoints; ++i) {
+    // Ensure each point in the line string is an array
+    Check_Type(rb_ary_entry(line_string, i), T_ARRAY);
+
     double newLat = NUM2DBL(rb_ary_entry(rb_ary_entry(line_string, i), 0));
     double newLon = NUM2DBL(rb_ary_entry(rb_ary_entry(line_string, i), 1));
 

--- a/lib/lazer_lines/version.rb
+++ b/lib/lazer_lines/version.rb
@@ -1,3 +1,3 @@
 module LazerLines
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lazer_lines_spec.rb
+++ b/spec/lazer_lines_spec.rb
@@ -153,4 +153,34 @@ describe LazerLines do
     end
     #it { should == single_point_polyline }
   end
+
+  describe 'blank/empty encoded and decoding' do
+    it 'encodes [] into ""' do
+      expect(LazerLines.encode([], 5)).to eq('')
+    end
+
+    it 'decodes "" into []' do
+      expect(LazerLines.decode('', 5)).to eq([])
+    end
+  end
+
+  describe '.encode error handling' do
+    it 'raises an TypeError when the polyline is nil' do
+      expect { LazerLines.encode(nil, 5) }.to raise_error(TypeError)
+    end
+
+    it 'raises an TypeError when the polyline is [nil]' do
+      expect { LazerLines.encode([nil], 5) }.to raise_error(TypeError)
+    end
+
+    it 'raises an TypeError when the polyline is [[nil, nil]]' do
+      expect { LazerLines.encode([[nil, nil]], 5) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '.decode error handling' do
+    it 'raises an TypeError when the encoded polyline is nil' do
+      expect { LazerLines.decode(nil, 5) }.to raise_error(TypeError)
+    end
+  end
 end

--- a/spec/lazer_lines_spec.rb
+++ b/spec/lazer_lines_spec.rb
@@ -142,16 +142,27 @@ describe LazerLines do
     end
   end
 
-  describe 'encode a single point polyline' do
+  describe 'dealing with single point polylines' do
     let(:single_point_array) { [[-68.566641, 126.222309]] }
-    let(:single_point_polyline) { "`f~" }
+    let(:single_point_polyline) { "n|naLmxkaW" }
 
-    subject { LazerLines.encode(single_point_polyline, 5) }
-    it 'produces a valid polyline' do
-      puts subject.inspect
-      expect(subject).to eql(single_point_polyline)
+    context 'encoding' do
+      subject { LazerLines.encode(single_point_array, 5) }
+
+      it 'produces a valid polyline' do
+        expect(subject).to eql(single_point_polyline)
+      end
     end
-    #it { should == single_point_polyline }
+
+    describe 'decoding' do
+      let(:single_point_array) { [[-68.56664, 126.22231]] }
+
+      subject { LazerLines.decode(single_point_polyline, 5) }
+
+      it 'produces a valid polyline' do
+        expect(subject).to eql(single_point_array)
+      end
+    end
   end
 
   describe 'blank/empty encoded and decoding' do


### PR DESCRIPTION
Add specs for additional error/edge cases.
Bump version from `0.1.0` to `0.1.1`.
